### PR TITLE
Mod compatibility patch updates & fixes

### DIFF
--- a/GameData/SXT/ModCompatibility/FerramAeroSpaceTweaks.cfg
+++ b/GameData/SXT/ModCompatibility/FerramAeroSpaceTweaks.cfg
@@ -38,7 +38,7 @@
 // --
 
 // --
-@PART[SXTelevonSmall]:NEEDS[FerramAerospaceResearch|NEAR] {
+@PART[SXTelevonSmall]:NEEDS[FerramAerospaceResearch] {
     @maximum_drag = 0
     @minimum_drag = 0
     @angularDrag = 0
@@ -54,7 +54,7 @@
 		%transformName = Elevon1
 	}
 }
-@PART[SXTn1GridFin]:NEEDS[FerramAerospaceResearch|NEAR] {
+@PART[SXTn1GridFin]:NEEDS[FerramAerospaceResearch] {
     @maximum_drag = 0
     @minimum_drag = 0
     @angularDrag = 0
@@ -68,7 +68,7 @@
 		MidChordSweep = 0
 	}
 }
-@PART[SXTelevonSmallHalf]:NEEDS[FerramAerospaceResearch|NEAR] {
+@PART[SXTelevonSmallHalf]:NEEDS[FerramAerospaceResearch] {
     @maximum_drag = 0
     @minimum_drag = 0
     @angularDrag = 0
@@ -85,7 +85,7 @@
 	}
 }
 
-@PART[SXTWingSmallFolding]:NEEDS[FerramAerospaceResearch|NEAR] {
+@PART[SXTWingSmallFolding]:NEEDS[FerramAerospaceResearch] {
     @maximum_drag = 0
     @minimum_drag = 0
     @angularDrag = 0
@@ -105,7 +105,7 @@
 	}
 }
 	
-@PART[SXTelevonLarge]:NEEDS[FerramAerospaceResearch|NEAR] {
+@PART[SXTelevonLarge]:NEEDS[FerramAerospaceResearch] {
     @maximum_drag = 0
     @minimum_drag = 0
     @angularDrag = 0
@@ -121,7 +121,7 @@
 		%transformName = Elevon1
 	}
 }
-@PART[SXTelevonVeryLarge]:NEEDS[FerramAerospaceResearch|NEAR] {
+@PART[SXTelevonVeryLarge]:NEEDS[FerramAerospaceResearch] {
     @maximum_drag = 0
     @minimum_drag = 0
     @angularDrag = 0
@@ -149,13 +149,13 @@
 		%rootMidChordOffsetFromOrig = 0, 1.8, 0
 	}
 }
-@PART[SXTCargoBay1]:NEEDS[FerramAerospaceResearch|NEAR]
+@PART[SXTCargoBay1]:NEEDS[FerramAerospaceResearch]
 {
     @minimum_drag = 0
     @maximum_drag = 0
     @angularDrag = 0
 }
-@PART[SXTWingVeryLarge]:NEEDS[FerramAerospaceResearch|NEAR] {
+@PART[SXTWingVeryLarge]:NEEDS[FerramAerospaceResearch] {
     @module = Part
     @maximum_drag = 0
     @minimum_drag = 0
@@ -163,8 +163,17 @@
     !dragCoeff = DELETE
     !deflectionLiftCoeff = DELETE
 	!MODULE[ModuleLiftingSurface] {}
+
+	MODULE
+	{
+		name = FARWingAerodynamicModel
+		MAC = 7.99375
+		MidChordSweep = 21.25
+		b_2 = 22.03125
+		TaperRatio = 0.1419
+	}
 }
-@PART[SXTWingLarge]:NEEDS[FerramAerospaceResearch|NEAR] {
+@PART[SXTWingLarge]:NEEDS[FerramAerospaceResearch] {
     @module = Part
     @maximum_drag = 0
     @minimum_drag = 0
@@ -172,8 +181,17 @@
     !dragCoeff = DELETE
     !deflectionLiftCoeff = DELETE
 	!MODULE[ModuleLiftingSurface] {}
+
+	MODULE
+	{
+		name = FARWingAerodynamicModel
+		MAC = 3.65
+		MidChordSweep = 35.2
+		b_2 = 8.52
+		TaperRatio = 0.2373
+	}
 }
-@PART[SXTWingSmall]:NEEDS[FerramAerospaceResearch|NEAR] {
+@PART[SXTWingSmall]:NEEDS[FerramAerospaceResearch] {
     @module = Part
     @maximum_drag = 0
     @minimum_drag = 0
@@ -181,8 +199,17 @@
     !dragCoeff = DELETE
     !deflectionLiftCoeff = DELETE
 	!MODULE[ModuleLiftingSurface] {}
+
+	MODULE
+	{
+		name = FARWingAerodynamicModel
+		MAC = 1.15
+		MidChordSweep = 0
+		b_2 = 2
+		TaperRatio = 1
+	}
 }
-@PART[SXTWingSmallHalf]:NEEDS[FerramAerospaceResearch|NEAR] {
+@PART[SXTWingSmallHalf]:NEEDS[FerramAerospaceResearch] {
     @module = Part
     @maximum_drag = 0
     @minimum_drag = 0
@@ -190,8 +217,17 @@
     !dragCoeff = DELETE
     !deflectionLiftCoeff = DELETE
 	!MODULE[ModuleLiftingSurface] {}
+
+	MODULE
+	{
+		name = FARWingAerodynamicModel
+		MAC = 1.15
+		MidChordSweep = 0
+		b_2 = 1
+		TaperRatio = 1
+	}
 }
-@PART[SXTWingTipRound]:NEEDS[FerramAerospaceResearch|NEAR] {
+@PART[SXTWingTipRound]:NEEDS[FerramAerospaceResearch] {
     @module = Part
     @maximum_drag = 0
     @minimum_drag = 0
@@ -199,4 +235,13 @@
     !dragCoeff = DELETE
     !deflectionLiftCoeff = DELETE
     !MODULE[ModuleLiftingSurface] {}
+
+	MODULE
+	{
+		name = FARWingAerodynamicModel
+        b_2 = 1
+        MAC = 2.25
+        TaperRatio = 0.35
+        MidChordSweep = 0
+    }
 }

--- a/GameData/SXT/ModCompatibility/SXT_KAS.cfg
+++ b/GameData/SXT/ModCompatibility/SXT_KAS.cfg
@@ -7,6 +7,15 @@ MODULE
 }
 }
 
+@PART[MEMDescentMod]:NEEDS[KAS]
+{
+    MODULE
+    {
+        name = KASModuleContainer
+        maxSize = 30
+    }
+}
+
 @PART[SXTPipeHub]:NEEDS[KAS]
 {
 	 MODULE

--- a/GameData/SXT/Parts/Aviation/Aero/Wing/part.cfg
+++ b/GameData/SXT/Parts/Aviation/Aero/Wing/part.cfg
@@ -55,12 +55,4 @@ rescaleFactor = 1
 		dragAtMaxAoA = 0.1
 		dragAtMinAoA = 0.0
 	}
-	MODULE
-	{
-		name = FARWingAerodynamicModel
-		MAC = 1.15
-		MidChordSweep = 0
-		b_2 = 2
-		TaperRatio = 1
-	}
 }

--- a/GameData/SXT/Parts/Aviation/Aero/Wing/partHalf.cfg
+++ b/GameData/SXT/Parts/Aviation/Aero/Wing/partHalf.cfg
@@ -55,13 +55,4 @@ rescaleFactor = 1
 		dragAtMaxAoA = 0.08
 		dragAtMinAoA = 0.0
 	}
-	MODULE:NEEDS[FerramAerospaceResearch]
-	{
-		name = FARWingAerodynamicModel
-		MAC = 1.15
-		MidChordSweep = 0
-		b_2 = 1
-		TaperRatio = 1
-	}
-	
 }

--- a/GameData/SXT/Parts/Aviation/Aero/Wing/partLarge.cfg
+++ b/GameData/SXT/Parts/Aviation/Aero/Wing/partLarge.cfg
@@ -60,13 +60,4 @@ MODEL
 		 amount = 0
 		 maxAmount = 300
 	}
-	MODULE
-	{
-		name = FARWingAerodynamicModel
-		MAC = 3.65
-		MidChordSweep = 35.2
-		b_2 = 8.52
-		TaperRatio = 0.2373
-	}
-
 }

--- a/GameData/SXT/Parts/Aviation/Aero/Wing/partLarger.cfg
+++ b/GameData/SXT/Parts/Aviation/Aero/Wing/partLarger.cfg
@@ -62,13 +62,4 @@ rescaleFactor = 1
 		 amount = 0
 		 maxAmount = 1000
 	}
-	MODULE
-	{
-		name = FARWingAerodynamicModel
-		MAC = 7.99375
-		MidChordSweep = 21.25
-		b_2 = 22.03125
-		TaperRatio = 0.1419
-	}
-
 }

--- a/GameData/SXT/Parts/Aviation/Aero/Wing/partWingTipRound.cfg
+++ b/GameData/SXT/Parts/Aviation/Aero/Wing/partWingTipRound.cfg
@@ -56,12 +56,4 @@ description = We got slightly over-enthusiastic when we discovered the factory c
 		dragAtMaxAoA = 0.12
 		dragAtMinAoA = 0.0
 	}
-	MODULE
-	{
-		name = FARWingAerodynamicModel
-        b_2 = 1
-        MAC = 2.25
-        TaperRatio = 0.35
-        MidChordSweep = 0
-    }
 }

--- a/GameData/SXT/Parts/Probes/Command/Dontstay/partProbe.cfg
+++ b/GameData/SXT/Parts/Probes/Command/Dontstay/partProbe.cfg
@@ -18,6 +18,10 @@ CrewCapacity = 0
 
 node_stack_bottom = 0.0, -0.515425, 0.0, 0, -1, 0, 0
 
+    fx_gasBurst_white = 0.0, 0.515425, 0.0, 0.0, -1.0, 0.0, decouple
+
+    sound_decoupler_fire = decouple
+
 TechRequired = start
 entryCost = 1400
 cost = 300

--- a/GameData/SXT/Parts/Rocketry/Command/MEM/partDescentModule.cfg
+++ b/GameData/SXT/Parts/Rocketry/Command/MEM/partDescentModule.cfg
@@ -181,12 +181,6 @@ MODULE
 
 MODULE
 {
-	name = KASModuleContainer
-	maxSize = 30
-}
-
-MODULE
-{
     name = FlagDecal
     textureQuadName = flag
 }

--- a/GameData/SXT/Parts/Rocketry/Hull/RadialFuel/part.cfg
+++ b/GameData/SXT/Parts/Rocketry/Hull/RadialFuel/part.cfg
@@ -81,7 +81,7 @@ MODULE
 
 MODULE
 {
-    name = ModuleToggleCrossFeed
+    name = ModuleToggleCrossfeed
     crossfeedStatus = false
     toggleEditor = true
     toggleFlight = true

--- a/GameData/SXT/Parts/StationsBases/Electrical/solarHex/part.cfg
+++ b/GameData/SXT/Parts/StationsBases/Electrical/solarHex/part.cfg
@@ -50,12 +50,5 @@ MODULE
 	animationName = solarpanels
 	resourceName = ElectricCharge
 	chargeRate = 1.5
-	powerCurve
- 	{
-		key = 206000000000 0 0 0
-		key = 13599840256 1 0 0
-		key = 68773560320 0.5 0 0
-		key = 0 10 0 0
- 	}
 }
 }

--- a/GameData/SXT/Parts/StationsBases/Electrical/solarHex/partLarge.cfg
+++ b/GameData/SXT/Parts/StationsBases/Electrical/solarHex/partLarge.cfg
@@ -53,28 +53,13 @@ maxTemp = 3200
 MODULE
 {
 	name = ModuleDeployableSolarPanel
-	
 	animationName = tksolar
-	
 	sunTracking = false
-	
 	raycastTransformName = rayCatcher
-	
 	pivotName = rayCatcher
-	
 	isBreakable = true
-	
 	resourceName = ElectricCharge
-	
 	chargeRate = 12
-	
-	powerCurve
- 	{
-		key = 206000000000 0 0 0
-		key = 13599840256 1 0 0
-		key = 68773560320 0.5 0 0
-		key = 0 10 0 0
- 	}
 }
 
 

--- a/GameData/SXT/Parts/StationsBases/Utility/structuralPanel/part.cfg
+++ b/GameData/SXT/Parts/StationsBases/Utility/structuralPanel/part.cfg
@@ -46,20 +46,4 @@ breakingForce = 200
 breakingTorque = 200
 maxTemp = 3200
 fuelCrossFeed = False
-
-MODULE
-{
-	name = KASModuleGrab
-	evaPartPos = (0.0, 0.10, -0.15)
-	evaPartDir = (0,0,-1)
-	storable = true
-	storedSize = 5
-	attachOnPart = True
-	attachOnEva = False
-	attachOnStatic = True
-	customGroundPos = true
-	dropPartPos = (0.0, -0.5, 0.0)
-	dropPartRot = (0.0, -1.0, 0.0)
-}
-
 }

--- a/GameData/SXT/Parts/StationsBases/Utility/structuralPanel/partHexagon.cfg
+++ b/GameData/SXT/Parts/StationsBases/Utility/structuralPanel/partHexagon.cfg
@@ -46,20 +46,4 @@ breakingForce = 200
 breakingTorque = 200
 maxTemp = 3200
 fuelCrossFeed = False
-
-MODULE
-{
-	name = KASModuleGrab
-	evaPartPos = (0.0, 0.10, -0.15)
-	evaPartDir = (0,0,-1)
-	storable = true
-	storedSize = 5
-	attachOnPart = True
-	attachOnEva = False
-	attachOnStatic = True
-	customGroundPos = true
-	dropPartPos = (0.0, -0.5, 0.0)
-	dropPartRot = (0.0, -1.0, 0.0)
-}
-
 }


### PR DESCRIPTION
- Remove references to the legacy NEAR mod.
- Move some FAR modules to the main FAR compatibility patch.
- Move some KAS modules to the main KAS compatibility patch.
- Add a missing decoupler FX to the Sputnik probe core.
- Remove some legacy power curves from the solar panels.
- Fix the crossfeed module name of the radia fuel tank.
